### PR TITLE
build: checkout specific commit instead of branch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -43,9 +43,17 @@ if [ -f "${tc_tar}" ]; then
 	rm "${tc_tar}"
 fi
 
+commit="bfbdf4360571"
+branch="toolchains.bootlin.com-${tc_tag}-${commit}"
+
 cd buildroot
 git clean -fdx
-git checkout toolchains.bootlin.com-"${tc_tag}"
+
+if git show-ref --quiet refs/heads/"$branch"; then
+    git checkout "$branch"
+else
+    git checkout -b "$branch" "$commit"
+fi
 
 cat ../"$1"-uclibc-config > ./.config
 


### PR DESCRIPTION
The checkout was done on a branch, which may point to different commits over time. To make the toolchain creation reproducible, switch to checking out a specific commit instead.